### PR TITLE
Fail when curl download of nim-install fails

### DIFF
--- a/core/rust1.34/Dockerfile
+++ b/core/rust1.34/Dockerfile
@@ -40,6 +40,7 @@ ARG GO_PROXY_BUILD_FROM=source
 
 # install nim
 ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl ${NIM_INSTALL_SCRIPT} | bash
 
 COPY --from=builder_source /bin/proxy /bin/proxy_source


### PR DESCRIPTION
Ensures that a failure of the nim download fails the image build.